### PR TITLE
Allowed empty array as arguments and selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 composer.phar
 /vendor/
+.phpunit.result.cache

--- a/src/TestGraphQL.php
+++ b/src/TestGraphQL.php
@@ -58,12 +58,12 @@ trait TestGraphQL
 
     private function prepareClient(GraphQLClient $client, $arguments, $selection)
     {
-        if ($arguments != null && $selection == null) {
+        if (!is_null($arguments) && is_null($selection)) {
             $client->setSelectionSet($arguments);
             return $client->getData();
         }
 
-        if ($arguments != null && $selection != null) {
+        if (!is_null($arguments) && !is_null($selection)) {
             $client->setArguments($arguments);
             $client->setSelectionSet($selection);
             return $client->getData();

--- a/tests/TestGraphQLTest.php
+++ b/tests/TestGraphQLTest.php
@@ -77,4 +77,21 @@ class TestGraphQLTest extends TestCase
         $this->assertEquals(['query' => "mutation { createAccount(id: 123){\nid\n} }"], $testCase->data);
     }
 
+    public function testMutationWithEmptyArrays()
+    {
+        $testCase = new FakeTestCase();
+
+        $testCase->mutation('logout', [], []);
+
+        $this->assertEquals(['query' => "mutation { logout }"], $testCase->data);
+    }
+
+    public function testMutationWithOneEmptyArrayArguments()
+    {
+        $testCase = new FakeTestCase();
+
+        $testCase->mutation('logout', [], ['success']);
+
+        $this->assertEquals(['query' => "mutation { logout{\nsuccess\n} }"], $testCase->data);
+    }
 }


### PR DESCRIPTION
For issue #3:
`$this->mutation('logout', [], ['status', 'message'])`
and
`$this->mutation('logout', [])`
always return GraphQLClient.

Use is_null instead of [] == null because in php empty array is equals to null

😄 


